### PR TITLE
use keyword syntax in tests

### DIFF
--- a/test/cljsv/core_test.clj
+++ b/test/cljsv/core_test.clj
@@ -6,7 +6,5 @@
 (deftest main-test
   (testing "stuff should work"
     (let [parsed (read-csv-str "this,that\na,b\nc,d")]
-      (is (= (first parsed) {"this" "a" "that" "b"}))
-      (is (= (second parsed) {"this" "c" "that" "d"})))))
-
-
+      (is (= (first parsed) {:this "a" :that "b"}))
+      (is (= (second parsed) {:this "c" :that "d"})))))

--- a/test/cljsv/files_test.clj
+++ b/test/cljsv/files_test.clj
@@ -14,7 +14,5 @@
           (doall
             (read-csv-file f)))))
   (testing "should have the correct content"
-    (is (some #(= % {"this" "1" "that" "2" "more" "stuff"})
+    (is (some #(= % {:this "1" :that "2" :more "stuff"})
               (read-csv-file test-fn)))))
-
-


### PR DESCRIPTION
Prepping for switch to keyword by default for column names in header consumption