### PR TITLE
speed up mappify using structs

### DIFF
--- a/src/semantic_csv/core.clj
+++ b/src/semantic_csv/core.clj
@@ -72,8 +72,10 @@
   ([{:keys [keyify] :or {keyify true} :as opts}
     rows]
    (let [header (first rows)
-         header (if keyify (mapv keyword header) header)]
-     (map (partial impl/mappify-row header) (rest rows)))))
+         header (if keyify (mapv keyword header) header)
+         s (apply create-struct header)]
+     (for [r (rest rows)]
+       (apply struct s r)))))
 
 ;; Here's an example to whet our whistle:
 ;;

--- a/src/semantic_csv/impl/core.clj
+++ b/src/semantic_csv/impl/core.clj
@@ -2,12 +2,6 @@
   "This namespace consists of implementation details for the main API")
 
 
-(defn mappify-row
-  "Translates a single row of values into a map of `colname -> val`, given colnames in `header`."
-  [header row]
-  (into {} (map vector header row)))
-
-
 (defn apply-kwargs
   "Utility that takes a function f, any number of regular args, and a final kw-args argument which will be
   splatted in as a final argument"


### PR DESCRIPTION
I basically have a mappify function in my current project (and soon won't since I'll be migrating it to use semantic-csv :)) and it became *much* faster when I switched it to use structs.