### PR TITLE
Add ->double conversion function.

### DIFF
--- a/src/semantic_csv/core.clj
+++ b/src/semantic_csv/core.clj
@@ -284,6 +284,11 @@
   [string]
   (Float/parseFloat string))
 
+(defn ->double
+  "Translate into double"
+  [string]
+  (Double/parseDouble string))
+
 ;;     (slurp-csv "test/test.csv"
 ;;                :cast-fns {:this ->int})
 


### PR DESCRIPTION
Another convenience function for parsing doubles.

Personally, I avoid floats in Clojure like the plague as doubles seems to be the blessed type, and using floats can lead to weirdness. I guess you have a particular use case for floats, hence the existing conversion function, but I wonder whether it might be sporting to also add a comment to the ->float docstring warning inexperienced users of the pitfalls?