### PR TITLE
Added `:transform-header` option to mappify.

### DIFF
--- a/src/semantic_csv/core.clj
+++ b/src/semantic_csv/core.clj
@@ -36,9 +36,6 @@
             [semantic-csv.impl.core :as impl :refer [?>>]]))
 
 
-(declare ->idiomatic-keyword)
-
-
 ;; To start, require this namespace, `clojure.java.io`, and your favorite CSV parser (e.g.,
 ;; [clojure-csv](https://github.com/davidsantiago/clojure-csv) or 
 ;; [clojure/data.csv](https://github.com/clojure/data.csv); we'll mostly be using the former).
@@ -85,11 +82,10 @@
          header (if header
                   header
                   (first rows))
-         header (if transform-header
-                  (mapv transform-header header)
-                  (if keyify
-                    (mapv ->idiomatic-keyword header)
-                    header))
+         header (cond
+                  transform-header (mapv transform-header header)
+                  keyify (mapv keyword header)
+                  :else header)
          map-fn (if structs
                   (let [s (apply create-struct header)]
                     (partial apply struct s))

--- a/src/semantic_csv/core.clj
+++ b/src/semantic_csv/core.clj
@@ -36,6 +36,9 @@
             [semantic-csv.impl.core :as impl :refer [?>>]]))
 
 
+(declare ->idiomatic-keyword)
+
+
 ;; To start, require this namespace, `clojure.java.io`, and your favorite CSV parser (e.g.,
 ;; [clojure-csv](https://github.com/davidsantiago/clojure-csv) or 
 ;; [clojure/data.csv](https://github.com/clojure/data.csv); we'll mostly be using the former).
@@ -85,7 +88,7 @@
          header (if transform-header
                   (mapv transform-header header)
                   (if keyify
-                    (mapv keyword header)
+                    (mapv ->idiomatic-keyword header)
                     header))
          map-fn (if structs
                   (let [s (apply create-struct header)]
@@ -342,20 +345,13 @@
 ;; # A Helper function to use with mappify to replace spaces in headers.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; ## replace-space
+;; ## ->idiomatic-keyword
 
-(defn replace-space
-  "Takes a string that is used to replace spaces and a bool, that when true, will make a keyword out of the header.
-  When no bool is passed, true is used, and headers will be made into keywords.
-  Returns a function, accepting a single parameter."
-  ([replace-string]
-   (replace-space replace-string true))
-  ([replace-string keyify]
-   (fn [r-string]
-     (let [header (clojure.string/replace r-string \space replace-string)]
-       (if keyify
-         (keyword header)
-         header)))))
+(defn ->idiomatic-keyword
+  "Takes a string, replacing consecutive underscores and spaces with a single dash(-),
+  then returns a keyword based on the transformed string."
+  [x]
+  (-> x (clojure.string/replace #"[ _]+" "-") clojure.string/lower-case keyword))
 
 ;; <br/>
 ;; # Some casting functions for your convenience

--- a/test/semantic_csv/core_test.clj
+++ b/test/semantic_csv/core_test.clj
@@ -22,10 +22,7 @@
              {:foo "this" :bar "that"})))
     (testing ":tranform-header overrides the :keyify option"
       (is (= (first (mappify {:transform-header identity :keyify true} data))
-             {"this" "x" "that" "y"})))
-    (testing ":keyify uses ->idiomatic-keyword by default"
-      (is (= (first (mappify {:header ["foo header" "bar_header"]} data))
-             {:foo-header "this" :bar-header "that"})))))
+             {"this" "x" "that" "y"})))))
 
 
 (deftest structify-test

--- a/test/semantic_csv/core_test.clj
+++ b/test/semantic_csv/core_test.clj
@@ -19,7 +19,13 @@
              {:this "# some comment"})))
     (testing "mappify should not consume header if :header is specified"
       (is (= (first (mappify {:header ["foo" "bar"]} data))
-             {:foo "this" :bar "that"})))))
+             {:foo "this" :bar "that"})))
+    (testing ":tranform-header overrides the :keyify option"
+      (is (= (first (mappify {:transform-header identity :keyify true} data))
+             {"this" "x" "that" "y"})))
+    (testing ":keyify uses ->idiomatic-keyword by default"
+      (is (= (first (mappify {:header ["foo header" "bar_header"]} data))
+             {:foo-header "this" :bar-header "that"})))))
 
 
 (deftest structify-test


### PR DESCRIPTION
For #26.  There is now a `:transform-header` option in mappify, that takes a function with a single string parameter.  I also added a helper that replaces spaces with a given string.  I added this because of the comment you mentioned on reddit in the original issue.