### PR TITLE
Sniffer

### DIFF
--- a/test/semantic_csv/core_test.clj
+++ b/test/semantic_csv/core_test.clj
@@ -55,6 +55,22 @@
              [["this" "is data"]])))))
 
 
+(deftest sniff-data-test
+  (let [data [{:int "10" :rational "3/2" :double "14.0" :other "string"}
+              {:int "23" :rational "7/1" :double "240" :other "4/10"}]
+        sniff-result {:int [:numeric :integer]
+                      :rational [:numeric :rational]
+                      :double [:numeric :decimal]
+                      :other [:string]}]
+    (testing "should return a proper sniff result"
+      (is (= (sniff-data {:do-cast false} data) sniff-result)))
+
+    (testing "should properly cast values"
+      (is (= (sniff-data data)
+             [{:int 10 :rational 3/2 :double 14.0 :other "string"}
+              {:int 23 :rational 7 :double 240.0 :other "4/10"}])))))
+
+
 (deftest cast-with-test
   (let [data [["this" "that"]
               ["1" "y"]]]


### PR DESCRIPTION
This is still a Work in progress.  I have only had a few lunches to get some things down, but it has been a little while, so I thought I would shoot this your way and let you have a look.  I moved away from regexes, because casting is just easier.  I also reduced the input data, which i called the `sniff-map` (naming suggestions appreciated), to just contain the overall data type as the key (i.e. `:numeric`), and a map containing the `:hierarchy`, and all the subtypes (i.e. `:integer`).  The value for `:hierarchy` being a vector, and each subtype has a casting function.  This seemed like a simple and intuitive way to order this, but I am happy to alter it if you have suggestions.  Also, the return value for `sniff-value` is a vector that acts as a path into the `sniff-map` (i.e. `[:numeric :integer]`).  This seemed like an intuitive way to get back to the casting function when the time comes.  

Some things I want to do:
- Add a function the deals with promoting/demoting types.  For example - some column may have a mix of integers and decimals, and at the end we want to make sure that the output is a decimal.  Also, there are cases where a string may be in a column that also has what could be numerics, and we need to signal that it should remain a string.  There are probably a number of ways to ensure this, but I haven't decided on one yet.
- Add some tests
- Add a function that applies the cast to the csv data.

Overall, I am still not totally satisfied, but I feel like it is going in the right direction.
