### PR TITLE
Make cast-row work with seqs

### DIFF
--- a/src/semantic_csv/impl/core.clj
+++ b/src/semantic_csv/impl/core.clj
@@ -57,7 +57,11 @@
                  (keys row)
                :else
                  (range (count row)))]
-    (reduce (row-val-caster cast-fns exception-handler) row cols)))
+    (reduce (row-val-caster cast-fns exception-handler)
+            (if (seq? row)
+              (vec row)
+              row)
+            cols)))
 
 
 ;; The following is ripped off from prismatic/plumbing:


### PR DESCRIPTION
Problem: if rows are seqs, we get a null pointer exception.
To reproduce:
```clojure
(csv/spit-csv "test.csv" (for [x (range 10)
                               y (range 10)]
                             (map inc [x y])))
```
I traced the problem to using update-in in row-val-caster. It turns out 
`(get my-seq 4)` (and by extension update-in) doesn't work as expected (it returns nil). This patch forces rows that are seqs to vec before doing the casting. 