### PR TITLE
`batch` is now a transducer. Transcribed core casting helpers.

### DIFF
--- a/src/semantic_csv/core.clj
+++ b/src/semantic_csv/core.clj
@@ -327,84 +327,28 @@
 
 ;; ## ->int
 
-(defn ->int
-  "Translate to int from string or other numeric. If string represents a non integer value,
-  it will be rounded down to the nearest int.
-
-  An opts map can be specified as the first arguments with the following options:
-  * `:nil-fill` - return this when input is empty/nil."
-  ([x]
-   (->int {} x))
-  ([{:keys [nil-fill]} x]
-   (cond
-     (impl/not-blank? x) (-> x s/trim Double/parseDouble int)
-     (number? x) (int x)
-     :else nil-fill)))
+(def ->int #'td/->int)
+(alter-meta! #'->int merge (select-keys (meta #'td/->int) [:doc :arglist]))
 
 ;; ## ->long
 
-(defn ->long
-  "Translate to long from string or other numeric. If string represents a non integer value,
-  will be rounded down to the nearest long.
-
-  An opts map can be specified as the first arguments with the following options:
-  * `:nil-fill` - return this when input is empty/nil."
-  ([x]
-   (->long {} x))
-  ([{:keys [nil-fill]} x]
-   (cond
-     (impl/not-blank? x) (-> x s/trim Double/parseDouble long)
-     (number? x) (long x)
-     :else nil-fill)))
+(def ->long #'td/->long)
+(alter-meta! #'->long merge (select-keys (meta #'td/->long) [:doc :arglist]))
 
 ;; ## ->float
 
-(defn ->float
-  "Translate to float from string or other numeric.
-
-  An opts map can be specified as the first arguments with the following options:
-  * `:nil-fill` - return this when input is empty/nil."
-  ([x]
-   (->float {} x))
-  ([{:keys [nil-fill]} x]
-   (cond
-     (impl/not-blank? x) (-> x s/trim Float/parseFloat)
-     (number? x) (float x)
-     :else nil-fill)))
+(def ->float #'td/->float)
+(alter-meta! #'->float merge (select-keys (meta #'td/->float) [:doc :arglist]))
 
 ;; ## ->double
 
-(defn ->double
-  "Translate to double from string or other numeric.
-
-  An opts map can be specified as the first arguments with the following options:
-  * `:nil-fill` - return this when input is empty/nil."
-  ([x]
-   (->double {} x))
-  ([{:keys [nil-fill]} x]
-   (cond
-     (impl/not-blank? x) (-> x s/trim Double/parseDouble)
-     (number? x) (double x)
-     :else nil-fill)))
+(def ->double #'td/->double)
+(alter-meta! #'->double merge (select-keys (meta #'td/->double) [:doc :arglist]))
 
 ;; ## ->boolean
 
-(defn ->boolean
-  "Translate to boolean from string or other numeric.
-
-  An opts map can be specified as the first arguments with the following options:
-  * `:nil-fill` - return this when input is empty/nil."
-  ([x]
-   (->boolean {} x))
-  ([{:keys [nil-fill]} x]
-   (cond
-     (string? x) (case (-> x s/trim s/lower-case)
-                   ("true" "yes" "t") true
-                   ("false" "no" "f") false
-                   "" nil-fill)
-     (number? x) (not (zero? x))
-     (nil? x) nil-fill
-     :else (boolean x))))
+(def ->boolean #'td/->boolean)
+(alter-meta! #'->boolean merge (select-keys (meta #'td/->boolean) [:doc :arglist]))
 
 
 ;;     (slurp-csv "test/test.csv"

--- a/test/semantic_csv/transducers_test.clj
+++ b/test/semantic_csv/transducers_test.clj
@@ -190,8 +190,8 @@
 (deftest batch-test
   (let [xs (for [i (range 20)] [i (* i 2)])]
     (testing "makes the right number of batches"
-      (is (= (count (batch 7 xs))
+      (is (= (count (sequence (batch 7) xs))
              3)))
     (testing "doesn't put more things than it should in final batch"
-      (is (= (->> xs (batch 7) last count)
+      (is (= (->> xs (sequence (batch 7)) last count)
              6)))))


### PR DESCRIPTION
In response to #30 (well, parts of it anyway):

I converted batch to use `partition-all`, which will give use a transducer.  This also allows spit to be written with transducers. Double winzies! Hence, I converted spit to use `transduce`.

I also brought over the updated cast helpers updates to the transducers namespace.  I referred to them since `core` was already referring to `transducers`. I used `alter-meta` to make sure they share doc strings and arglists.