### PR TITLE
Fix #47

### DIFF
--- a/src/semantic_csv/transducers.clj
+++ b/src/semantic_csv/transducers.clj
@@ -454,17 +454,18 @@
      (with-open [file-handle (io/writer file)]
        (spit-csv file-handle opts rows))
      ; Else assume we already have a file handle
-     (let [cast-xf   (when cast-fns (cast-with cast-fns))
-           vect-xf   (when (-> rows first map?) (vectorize {:header header :prepend-header prepend-header}))]
-       (transduce (comp (apply comp (remove nil? [cast-xf vect-xf]))
-                        (cast-with str)
-                        (batch batch-size)
-                        (map #(impl/apply-kwargs csv/write-csv % writer-opts)))
-                  (fn [w rowstr]
-                    (.write w rowstr)
-                    w)
-                  file
-                  rows)))))
+     (let [cast-xf (when cast-fns (cast-with cast-fns))
+           vect-xf (when (-> rows first map?) (vectorize {:header header :prepend-header prepend-header}))]
+       (reduce (fn [w rowstr]
+                 (when rowstr
+                   (.write w rowstr))
+                 w)
+               file
+               (sequence (comp (apply comp (remove nil? [cast-xf vect-xf]))
+                               (cast-with str)
+                               (batch batch-size)
+                               (map #(impl/apply-kwargs csv/write-csv % writer-opts)))
+                         rows))))))
 
 ;; Note that since we use `clojure-csv` here, we offer a `:batch-size` option that lets you format and write small
 ;; batches of rows out at a time, to avoid constructing a massive string representation of all the data in the


### PR DESCRIPTION
Sorry about that.  I don't think I ran the file tests like I thought I did. I refactored it to used `sequence` with a transducer, which ends up going to reduces.  this felt like a classic case for `transduce`, but for whatever reason - I suspect it has to do with `batch`ing - `transduce` isn't being `reduced` at the right time, and an empty input is getting passed to the reducing function, which is why we see the Arguments exception. I tried altering the reducing function to have this signature -> `(fn [w & [rowstr]] ...)`, which proved my thought process and fixed the error. However, leaving that in there felt a little hack-ish as it was just circumventing an undesired, and unintended behavior.