### PR TITLE
fix: added nil to empty values

### DIFF
--- a/src/semantic_csv/impl/core.cljc
+++ b/src/semantic_csv/impl/core.cljc
@@ -4,10 +4,23 @@
   (:require [clojure.string :as s]))
 
 
+(defn zipmap-keys
+  "Returns a map with the keys mapped to the corresponding vals.
+   Will add nil values if vals is smaller than keys."
+  [keys vals]
+  (loop [map {}
+         ks (seq keys)
+         vs (seq vals)]
+    (if ks
+      (recur (assoc map (first ks) (first vs))
+             (next ks)
+             (next vs))
+      map)))
+
 (defn mappify-row
   "Translates a single row of values into a map of `colname -> val`, given colnames in `header`."
   [header row]
-  (into {} (map vector header row)))
+  (zipmap-keys header row))
 
 
 (defn apply-kwargs

--- a/test/semantic_csv/core_test.clj
+++ b/test/semantic_csv/core_test.clj
@@ -16,7 +16,7 @@
              {"this" "x" "that" "y"})))
     (testing "mappify should not regard comments"
       (is (= (last (mappify data))
-             {:this "# some comment"})))
+             {:this "# some comment" :that nil})))
     (testing "mappify should not consume header if :header is specified"
       (is (= (first (mappify {:header ["foo" "bar"]} data))
              {:foo "this" :bar "that"})))

--- a/test/semantic_csv/transducers_test.clj
+++ b/test/semantic_csv/transducers_test.clj
@@ -16,7 +16,7 @@
              {"this" "x" "that" "y"})))
     (testing "mappify should not regard comments"
       (is (= (last (into [] (mappify) data))
-             {:this "# some comment"})))
+             {:this "# some comment" :that nil})))
     (testing "mappify should not consume header if :header is specified"
       (is (= (first (into [] (mappify {:header ["foo" "bar"]}) data))
              {:foo "this" :bar "that"})))


### PR DESCRIPTION
I changed the `zipmap` default method so that it will always create a map with all the passed keys.
Another solution can be:
```clojure
(defn pad [n coll val]
        (take n (concat coll (repeat val))))

(defn mappify-row
  "Translates a single row of values into a map of `colname -> val`, given colnames in `header`."
  [header row]
  (zipmap header (pad (count header) row nil))) ; here we can replace nil with any default value passed by the user
```

Fixes #65 