### PR TITLE
Remove clojurescript dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,8 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.9.493"]
                  [clojure-csv/clojure-csv "2.0.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                                   [com.cemerick/piggieback "0.2.1"]]
                    :plugins      [[lein-marginalia "0.9.0"]]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}})
-
-


### PR DESCRIPTION
When using this library, our security scanner picks up vulnerabilities from the transitive dependencies of `org.clojure/clojurescript`, which this library depends on.

I'm not an expert, but I don't believe this library needs the dependency on `org.clojure/clojurescript` in order to be usable from Clojurescript. This change removes it.